### PR TITLE
feat: add google one tap support

### DIFF
--- a/src/signup/code-embeds/sign-up-buttons-component.html
+++ b/src/signup/code-embeds/sign-up-buttons-component.html
@@ -5,194 +5,8 @@ Following IDs are used in this script, and they should be attached to the button
 -->
 <script>
   (function handleSocialSignupButtons() {
-    const AUTH_BRIDGE_LOGIN_CALLBACK = 'https://admin.typeform.com/auth/okta/callback';
-    const OKTA_DOMAIN = 'https://auth.typeform.com/oauth2/default/v1/authorize';
-    const OKTA_CLIENT_ID = '0oa1nigb1jQqJMb7f4x7';
-    const GOOGLE_IDP_ID = '0oa1nic7hmTM5eytN4x7';
-    const MICROSOFT_IDP_ID = '0oa3ms5jd9FloU2RI4x7';
-    const OKTA_URL = 'https://auth.typeform.com/oauth2/default/v1/authorize'
-    // const COOKIE_DOMAIN = '.typeform.com'
-    const COOKIE_DOMAIN = 'typeform-website-cbf6fc2c8ca977b811c224.webflow.io'
-
-    function addCookiesData(signupData) {
-      const cookies = [
-        'gspk',
-        'gsxid',
-        '_ga',
-        '_fbp',
-        '_fbc',
-        'cje',
-      ].reduce((acc, cookie) => {
-        const value = Cookies.get(cookie)
-        return value ? { ...acc, [cookie]: value } : acc
-      }, {})
-
-      return {
-        ...signupData,
-        cookies,
-      }
-    }
-
-    function addParamsData(signupData) {
-      const currentSearchParams = new window.URLSearchParams(window.location.search)
-      return {
-        ...signupData,
-        searchParams: {
-          ...Object.fromEntries(currentSearchParams),
-          tid: window.tid,
-        },
-      }
-    }
-
-    function addReferrer(signupData) {
-      const data = { ...signupData }
-      if (document.referrer) {
-        data.referrer = document.referrer
-      }
-      return data
-    }
-
-    function addCelloReferralCode(signupData) {
-      const celloReferral = Cookies.get('cello-referral')
-      return celloReferral ? { ...signupData, celloReferral } : signupData
-    }
-
-    function addReferralCode(signupData) {
-      const currentSearchParams = new window.URLSearchParams(window.location.search)
-      const referralCode = currentSearchParams.get('rsCode')
-      return referralCode ? { ...signupData, referralCode } : signupData
-    }
-
-    function addPartnerStackData(signupData) {
-      const gspk = Cookies.get('gspk')
-      const gsxid = Cookies.get('gsxid')
-
-      let data
-
-      if (gspk && gsxid) {
-        try {
-          data = {
-            ...signupData,
-            partnerstack: {
-              partnerKey: window.atob(gspk),
-              userId: gsxid,
-            },
-          }
-        } catch (e) {
-          data = signupData
-        }
-      }
-
-      return data
-    }
-
-    function setPartnerStackCookiesFromParams() {
-      const currentSearchParams = new window.URLSearchParams(window.location.search)
-
-      const cookieConfig = getCookieConfig(90)
-
-      const gspk = currentSearchParams.get('gspk')
-      const gsxid = currentSearchParams.get('gsxid')
-
-      if (gspk && gsxid) {
-        // persist cookie only if gspk is legit
-        try {
-          window.atob(gspk)
-        } catch (e) {
-          return
-        }
-        Cookies.set('gspk', gspk, cookieConfig)
-        Cookies.set('gsxid', gsxid, cookieConfig)
-      }
-    }
-
-    const compose =
-      (...functions) =>
-        args =>
-          functions.reduceRight((arg, fn) => fn(arg), args)
-
-    function buildSignupExtra() {
-      return compose(
-        addCookiesData,
-        addParamsData,
-        addReferrer,
-        addCelloReferralCode,
-        addReferralCode,
-        addPartnerStackData
-      )({})
-    }
-
-    const getCookieConfig = (expirationInDays = '') => {
-      const config = {
-        path: '/',
-        domain: COOKIE_DOMAIN,
-        secure: true,
-        sameSite: 'none',
-        partitioned: true,
-      }
-
-      if (expirationInDays) {
-        config.expires = expirationInDays
-      }
-
-      return config
-    }
-
-    const generateId = (n = 22) => {
-      const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-      let text = ''
-      for (let i = 0; i < n; i++) {
-        text += chars.charAt(Math.floor(Math.random() * chars.length))
-      }
-      return text
-    }
-    const generateState = (newTabState = false) => {
-      const state = generateId();
-      const in10Minutes = (1 / (24 * 60)) * 10 // 1day => 24h * 60 mins
-      Cookies.set('signup_state', state, getCookieConfig(in10Minutes))
-
-      return state
-    }
-    const setSignupCookies = ({ provider, device }) => {
-      const cookieConfig = getCookieConfig(365)
-      const sessionCookieConfig = getCookieConfig()
-
-      Cookies.set('signup_provider', provider, getCookieConfig(365))
-
-      Cookies.set('signup_device', device, cookieConfig)
-      Cookies.set('signup_user_agent', navigator.userAgent, cookieConfig)
-      Cookies.set(
-        'signup_extra',
-        JSON.stringify(buildSignupExtra()),
-        sessionCookieConfig
-      )
-
-      setPartnerStackCookiesFromParams()
-    }
-
-    const state = generateState()
-
-    const getSocialSignupRedirectUrl = (idpId) => {
-      const params = {
-        client_id: OKTA_CLIENT_ID,
-        idp: idpId,
-        response_type: 'code',
-        scope: 'openid email',
-        redirect_uri: AUTH_BRIDGE_LOGIN_CALLBACK,
-        nonce: generateId(),
-        state,
-      }
-      const queries = new URLSearchParams(params)
-
-      const socialSignupRedirectUrl = new URL(OKTA_URL)
-      socialSignupRedirectUrl.search = queries.toString()
-
-      return socialSignupRedirectUrl.toString()
-    }
-
     const handleSocialSignupClick = (provider) => (event) => {
-      const device = isMobile.any ? 'mobile' : 'desktop' // ismobilejs added globaly
-      setSignupCookies({ provider, device })
+      window.signUpHelpers.setSignupCookies({ provider })
 
       window.trackingHelper.trackItemClicked({
         item: 'social_signup',
@@ -204,13 +18,16 @@ Following IDs are used in this script, and they should be attached to the button
       })
     }
 
-    const googleSignupButton = document.querySelector('#signup-buttons-google');
-    const microsoftSignupButton = document.querySelector('#signup-buttons-microsoft');
+    window.addEventListener("signup-helpers:loaded", () => {
+      console.log('signup-helpers:loaded');
+      const googleSignupButton = document.querySelector('#signup-buttons-google');
+      const microsoftSignupButton = document.querySelector('#signup-buttons-microsoft');
 
-    googleSignupButton.setAttribute('href', getSocialSignupRedirectUrl(GOOGLE_IDP_ID));
-    microsoftSignupButton.setAttribute('href', getSocialSignupRedirectUrl(MICROSOFT_IDP_ID));
+      googleSignupButton.setAttribute('href', window.signUpHelpers.getSocialSignupRedirectUrl('google'));
+      microsoftSignupButton.setAttribute('href', window.signUpHelpers.getSocialSignupRedirectUrl('microsoft'));
 
-    googleSignupButton.addEventListener('click', handleSocialSignupClick('Google'));
-    microsoftSignupButton.addEventListener('click', handleSocialSignupClick('Microsoft'));
+      googleSignupButton.addEventListener('click', handleSocialSignupClick('Google'));
+      microsoftSignupButton.addEventListener('click', handleSocialSignupClick('Microsoft'));
+    })
   })();
 </script>

--- a/src/signup/google-one-tap.js
+++ b/src/signup/google-one-tap.js
@@ -1,0 +1,145 @@
+<script>
+  (function googleOneTapInitScope() {
+    const ONE_TAP_BLOCKED_URLS = [
+      '/signup/',
+      '/refer-a-friend/invite/',
+      '/careers/',
+    ]
+    const GOOGLE_CLIENT_ID = '6362390987-tg4ho08ait31oaomjia4367ln4e047qd.apps.googleusercontent.com';
+
+    function log(...args) {
+      window.__DEBUG_ONETAP__ && console.trace('[GoogleOneTap]', ...args);
+    };
+
+    function parseJwt(token) {
+      var base64Url = token.split('.')[1];
+      var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+      var jsonPayload = decodeURIComponent(window.atob(base64).split('').map(function (c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+      }).join(''));
+
+      return JSON.parse(jsonPayload);
+    }
+
+    function isOneTapSupported() {
+      const isVisitorAuthenticated = Cookies.get('tf_email'); // defined in root level
+      const hasTargetingConsent = consentUtil.hasTargetingConsent(); // defined in root level
+      const isMobileDevice = isMobile.any // defined in root level
+
+      if (isVisitorAuthenticated || !hasTargetingConsent) {
+        return false
+      }
+
+      if (isMobile.any) {
+        return false
+      }
+
+      if (ONE_TAP_BLOCKED_URLS.some(path => window.location.pathname.includes(path))) {
+        return false
+      }
+
+      return true
+    }
+
+    function initGoogleOneTap() {
+      if (!isOneTapSupported()) {
+        return;
+      }
+
+      const googleOneTapScript = document.createElement('script');
+      googleOneTapScript.src = 'https://accounts.google.com/gsi/client';
+      googleOneTapScript.async = true;
+      googleOneTapScript.id = "google-one-tap-script";
+      googleOneTapScript.onload = function () {
+        const { google } = window;
+
+        google.accounts.id.initialize({
+          client_id: GOOGLE_CLIENT_ID,
+          context: 'signup',
+          itp_support: true,
+          use_fedcm_for_prompt: true,
+          cancel_on_tap_outside: false,
+          callback: function googleClientInitializeCallback(credentialResponse) {
+            if (!credentialResponse?.credential) {
+              window.trackingHelper.trackTmpItemClicked('google_one_tap_response_no_credential')
+
+              log(`Response doesn't have credential`)
+              return
+            }
+
+            // Needed to update navigation menu avatar to show loading staate
+            window.dispatchEvent(new Event('user:loading'));
+
+            let decodedToken = undefined
+            try {
+              decodedToken = parseJwt(
+                credentialResponse?.credential
+              )
+
+              if (!decodedToken?.email) {
+                throw new Error('Empty token or email')
+              }
+            } catch (error) {
+              window.trackingHelper.trackTmpItemClicked('google_one_tap_response_faulty_token')
+              log(`Token decode error, ${error?.message}`)
+
+              window.dispatchEvent(new Event('user:initial'));
+              return
+            }
+
+            const redirectUrl = window.signUpHelpers.getSocialSignupRedirectUrl(
+              'google',
+              decodedToken.email
+            )
+
+            window.signUpHelpers.setSignupCookies({ provider: 'google', isOneTap: true })
+
+            window.trackingHelper.trackItemClicked({
+              item: 'social_signup',
+              item_type: 'one_tap',
+              label: 'google',
+              location: 'body',
+              typeform_property: 'admin_access',
+            })
+
+            window.trackingHelper.trackTmpItemClicked('google_one_tap_signup')
+
+            window.location.href = redirectUrl
+          },
+        })
+
+        window.trackingHelper.trackTmpItemClicked('google_one_tap_client_initialized');
+
+        google.accounts.id.prompt(notification => {
+          switch (notification.getMomentType()) {
+            case 'display':
+              window.trackingHelper.trackTmpItemClicked('google_one_tap_prompt_displayed');
+              break;
+            case 'dismissed': {
+              const dismissedReason = notification.getDismissedReason()
+
+              window.trackingHelper.trackTmpItemClicked(`google_one_tap_prompt_dismissed_${dismissedReason}`);
+              break;
+            }
+            case 'skipped':
+              window.trackingHelper.trackTmpItemClicked('google_one_tap_prompt_skipped');
+              break;
+          }
+        })
+      };
+    }
+
+    window.addEventListener("signup-helpers:loaded", () => {
+      console.log('signup-helpers:loaded');
+      const hasTargetingConsent = consentUtil?.hasTargetingConsent?.();
+
+      if (hasTargetingConsent) {
+        initGoogleOneTap()
+      } else {
+        window.addEventListener("OneTrustGroupsUpdated", function () {
+          initGoogleOneTap();
+        });
+      }
+    });
+  })();
+</script

--- a/src/signup/signup-helpers.js
+++ b/src/signup/signup-helpers.js
@@ -1,0 +1,216 @@
+(function signUpHelpersScope() {
+  const AUTH_BRIDGE_LOGIN_CALLBACK =
+    "https://admin.typeform.com/auth/okta/callback";
+  const OKTA_URL = "https://auth.typeform.com/oauth2/default/v1/authorize";
+  const OKTA_CLIENT_ID = "0oa1nigb1jQqJMb7f4x7";
+  const IDP_IDS = {
+    google: "0oa1nic7hmTM5eytN4x7",
+    microsoft: "0oa3ms5jd9FloU2RI4x7",
+  };
+  const COOKIE_DOMAIN = ".typeform.com";
+
+  function addCookiesData(signupData) {
+    const cookies = ["gspk", "gsxid", "_ga", "_fbp", "_fbc", "cje"].reduce(
+      (acc, cookie) => {
+        const value = Cookies.get(cookie);
+        return value ? { ...acc, [cookie]: value } : acc;
+      },
+      {}
+    );
+
+    return {
+      ...signupData,
+      cookies,
+    };
+  }
+
+  function addParamsData(signupData) {
+    const currentSearchParams = new window.URLSearchParams(
+      window.location.search
+    );
+    return {
+      ...signupData,
+      searchParams: {
+        ...Object.fromEntries(currentSearchParams),
+        tid: window.tid,
+      },
+    };
+  }
+
+  function addReferrer(signupData) {
+    const data = { ...signupData };
+    if (document.referrer) {
+      data.referrer = document.referrer;
+    }
+    return data;
+  }
+
+  function addCelloReferralCode(signupData) {
+    const celloReferral = Cookies.get("cello-referral");
+    return celloReferral ? { ...signupData, celloReferral } : signupData;
+  }
+
+  function addReferralCode(signupData) {
+    const currentSearchParams = new window.URLSearchParams(
+      window.location.search
+    );
+    const referralCode = currentSearchParams.get("rsCode");
+    return referralCode ? { ...signupData, referralCode } : signupData;
+  }
+
+  function addPartnerStackData(signupData) {
+    const gspk = Cookies.get("gspk");
+    const gsxid = Cookies.get("gsxid");
+
+    let data;
+
+    if (gspk && gsxid) {
+      try {
+        data = {
+          ...signupData,
+          partnerstack: {
+            partnerKey: window.atob(gspk),
+            userId: gsxid,
+          },
+        };
+      } catch (e) {
+        data = signupData;
+      }
+    }
+
+    return data;
+  }
+
+  function addOneTapData(isOneTap = false) {
+    return (signupData) => {
+      return isOneTap ? { ...signupData, isOneTap: "yes" } : signupData;
+    };
+  }
+
+  function setPartnerStackCookiesFromParams() {
+    const currentSearchParams = new window.URLSearchParams(
+      window.location.search
+    );
+
+    const cookieConfig = getCookieConfig(90);
+
+    const gspk = currentSearchParams.get("gspk");
+    const gsxid = currentSearchParams.get("gsxid");
+
+    if (gspk && gsxid) {
+      // persist cookie only if gspk is legit
+      try {
+        window.atob(gspk);
+      } catch (e) {
+        return;
+      }
+      Cookies.set("gspk", gspk, cookieConfig);
+      Cookies.set("gsxid", gsxid, cookieConfig);
+    }
+  }
+
+  const compose =
+    (...functions) =>
+    (args) =>
+      functions.reduceRight((arg, fn) => fn(arg), args);
+
+  function buildSignupExtra(isOneTap = false) {
+    return compose(
+      addCookiesData,
+      addParamsData,
+      addReferrer,
+      addCelloReferralCode,
+      addReferralCode,
+      addOneTapData(isOneTap),
+      addPartnerStackData
+    )({});
+  }
+
+  function getCookieConfig(expirationInDays = "") {
+    const config = {
+      path: "/",
+      domain: COOKIE_DOMAIN,
+      secure: true,
+      sameSite: "none",
+      partitioned: true,
+    };
+
+    if (expirationInDays) {
+      config.expires = expirationInDays;
+    }
+
+    return config;
+  }
+
+  function generateId(n = 22) {
+    const chars =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let text = "";
+    for (let i = 0; i < n; i++) {
+      text += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return text;
+  }
+
+  function generateState(newTabState = false) {
+    const state = generateId();
+    const in10Minutes = (1 / (24 * 60)) * 10; // 1day => 24h * 60 mins
+    Cookies.set("signup_state", state, getCookieConfig(in10Minutes));
+
+    return state;
+  }
+  function setSignupCookies({ provider, isOneTap }) {
+    const cookieConfig = getCookieConfig(365);
+    const sessionCookieConfig = getCookieConfig();
+    const device = isMobile.any ? "mobile" : "desktop";
+    const computedIsOneTap = isOneTap || false;
+
+    Cookies.set("signup_provider", provider, getCookieConfig(365));
+
+    Cookies.set("signup_device", computedDevice, cookieConfig);
+    Cookies.set("signup_user_agent", navigator.userAgent, cookieConfig);
+    Cookies.set(
+      "signup_extra",
+      JSON.stringify(buildSignupExtra(isOneTap)),
+      sessionCookieConfig
+    );
+
+    setPartnerStackCookiesFromParams();
+  }
+
+  function getSocialSignupRedirectUrl(idpName, loginHint) {
+    const state = generateState();
+    const idp = IDP_IDS[idpName];
+
+    if (!idp) {
+      throw new Error(`IDP ID for ${idpName} not found`);
+    }
+
+    const params = {
+      client_id: OKTA_CLIENT_ID,
+      idp,
+      response_type: "code",
+      scope: "openid email",
+      redirect_uri: AUTH_BRIDGE_LOGIN_CALLBACK,
+      nonce: generateId(),
+      state,
+    };
+    const queries = new URLSearchParams(params);
+
+    if (loginHint) {
+      queries.append("login_hint", loginHint);
+    }
+
+    const socialSignupRedirectUrl = new URL(OKTA_URL);
+    socialSignupRedirectUrl.search = queries.toString();
+
+    return socialSignupRedirectUrl.toString();
+  }
+
+  window.signUpHelpers = {
+    setSignupCookies,
+    getSocialSignupRedirectUrl,
+  };
+
+  window.dispatchEvent(new Event("signup-helpers:loaded"));
+})();

--- a/src/t/js-t.js
+++ b/src/t/js-t.js
@@ -179,6 +179,15 @@
         trackingClient.trackItemClicked(props);
         log("item_clicked", props);
       },
+      trackTmpItemClicked: (item, props) => {
+        const trackingProps = {
+          ...getMandatoryProperties(),
+          item,
+          ...props,
+        }
+        trackingClient.trackTmpItemClicked(trackingProps);
+        log("tmp_item_clicked", props);
+      },
       trackSignup: (url, label, location = "") => {
         window.trackingHelper.trackItemClicked({
           item: "sign_up",


### PR DESCRIPTION
- Moves signup helpers logic from signup buttons component to shared api under `window.signUpHelpers`
- Adds google one tap code, that should be added the global body
- Add tmpItemClicked event helper to trackingHelper