### PR TITLE
feat(WEB-8123): use new delete cookie handler from js tracking

### DIFF
--- a/src/t/js-t.js
+++ b/src/t/js-t.js
@@ -360,7 +360,7 @@
   }
 
   function handleRejectCookies() {
-    window.cookiesUtil.deleteNonStrictlyNecessaryCookies();
+    window.cookiesUtil.deleteAllNonStrictlyNecessaryCookies();
 
     // Cello attribution library sets all of its cookies twice for both .typeform.com and www.typeform.com domain
     // .typeform.com cookies can be deleted via js-tracking util but not www.typeform.com domain cookies.


### PR DESCRIPTION
# Description
Updates helper used for cookie deletion. 

# Requirements

**js-tracking script version should be upgraded to 19.2.0**
```html
<script src="https://public-assets.typeform.com/public/js-tracking/19.2.0/attributionUtil.js"></script>
<script src="https://public-assets.typeform.com/public/js-tracking/19.2.0/consentUtil.js"></script>
<script src="https://public-assets.typeform.com/public/js-tracking/19.2.0/trackingClient.js"></script>
<script src="https://public-assets.typeform.com/public/js-tracking/19.2.0/cookiesUtil.js"></script>
```